### PR TITLE
chore: fix repository url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/magicbell-io/node-client"
+    "url": "git+https://github.com/magicbell-io/magicbell-core"
   },
   "keywords": [
     "bell",


### PR DESCRIPTION
This fixes the repository in `package.json`, which also shows up on `npm`.

Because the package is named `@magicbell/core`, I've also renamed this repository from `magicbell-node` to `magicbell-core`, so things line up.